### PR TITLE
feat(settings): add per-device settings reset

### DIFF
--- a/Sources/MXControl/Settings/SettingsStore.swift
+++ b/Sources/MXControl/Settings/SettingsStore.swift
@@ -43,35 +43,25 @@ enum SettingsStore {
 
     // MARK: - Clear Settings
 
-    /// All known mouse setting suffixes — used by clearMouseSettings.
-    private static let mouseSettingKeys = [
-        "dpi", "pointer_speed",
-        "smartshift.active", "smartshift.torque", "smartshift.wheel_mode",
-        "hires.enabled", "hires.inverted",
-        "thumbwheel.inverted",
-        "button_remaps",
-        "gesture.click_time", "gesture.drag_threshold",
-    ]
-
-    /// All known keyboard setting suffixes — used by clearKeyboardSettings.
-    private static let keyboardSettingKeys = [
-        "backlight.enabled", "backlight.level",
-        "fn.inverted",
-    ]
+    /// Remove all saved settings for a device by clearing keys with the per-device prefix.
+    /// Uses prefix-based matching so new settings are automatically included without
+    /// maintaining a separate key list.
+    private static func clearSettings(for deviceName: String) {
+        let devicePrefix = "\(prefix).\(deviceName.lowercased().replacingOccurrences(of: " ", with: "_"))."
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(devicePrefix) {
+            defaults.removeObject(forKey: key)
+        }
+    }
 
     /// Remove all saved mouse settings for a device.
     static func clearMouseSettings(deviceName: String) {
-        for suffix in mouseSettingKeys {
-            defaults.removeObject(forKey: key(deviceName, suffix))
-        }
+        clearSettings(for: deviceName)
         logger.info("[SettingsStore] Cleared mouse settings for \(deviceName)")
     }
 
     /// Remove all saved keyboard settings for a device.
     static func clearKeyboardSettings(deviceName: String) {
-        for suffix in keyboardSettingKeys {
-            defaults.removeObject(forKey: key(deviceName, suffix))
-        }
+        clearSettings(for: deviceName)
         logger.info("[SettingsStore] Cleared keyboard settings for \(deviceName)")
     }
 

--- a/Sources/MXControl/UI/DeviceDetailView.swift
+++ b/Sources/MXControl/UI/DeviceDetailView.swift
@@ -129,7 +129,7 @@ struct MouseDetailView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.system(size: 10))
-                    Text("Reset to Default")
+                    Text("Clear Saved Settings")
                         .font(.system(size: 12))
                 }
                 .foregroundStyle(.red)
@@ -137,9 +137,9 @@ struct MouseDetailView: View {
                 .padding(.vertical, 8)
             }
             .buttonStyle(.plain)
-            .alert("Reset Settings", isPresented: $showResetConfirm) {
+            .alert("Clear Saved Settings", isPresented: $showResetConfirm) {
                 Button("Cancel", role: .cancel) {}
-                Button("Reset", role: .destructive) {
+                Button("Clear", role: .destructive) {
                     SettingsStore.clearMouseSettings(deviceName: mouse.name)
                     Task {
                         mouse.isFeaturesLoaded = false
@@ -147,7 +147,7 @@ struct MouseDetailView: View {
                     }
                 }
             } message: {
-                Text("This will clear all saved settings for \(mouse.name) and reload current values from the device.")
+                Text("This will remove all saved settings for \(mouse.name) and reload current values from the device.")
             }
         }
         .padding(.vertical, 4)
@@ -507,7 +507,7 @@ struct KeyboardDetailView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "arrow.counterclockwise")
                         .font(.system(size: 10))
-                    Text("Reset to Default")
+                    Text("Clear Saved Settings")
                         .font(.system(size: 12))
                 }
                 .foregroundStyle(.red)
@@ -515,9 +515,9 @@ struct KeyboardDetailView: View {
                 .padding(.vertical, 8)
             }
             .buttonStyle(.plain)
-            .alert("Reset Settings", isPresented: $showResetConfirm) {
+            .alert("Clear Saved Settings", isPresented: $showResetConfirm) {
                 Button("Cancel", role: .cancel) {}
-                Button("Reset", role: .destructive) {
+                Button("Clear", role: .destructive) {
                     SettingsStore.clearKeyboardSettings(deviceName: keyboard.name)
                     Task {
                         keyboard.isFeaturesLoaded = false
@@ -525,7 +525,7 @@ struct KeyboardDetailView: View {
                     }
                 }
             } message: {
-                Text("This will clear all saved settings for \(keyboard.name) and reload current values from the device.")
+                Text("This will remove all saved settings for \(keyboard.name) and reload current values from the device.")
             }
         }
         .padding(.vertical, 4)

--- a/Tests/MXControlTests/SettingsStoreTests.swift
+++ b/Tests/MXControlTests/SettingsStoreTests.swift
@@ -214,4 +214,108 @@ struct SettingsStoreTests {
         #expect(loaded.buttonRemaps != nil)
         #expect(loaded.buttonRemaps!.isEmpty)
     }
+
+    // MARK: - Clear Settings
+
+    @Test func clearMouseSettingsRemovesAllKeys() {
+        let name = uniqueDeviceName()
+        defer { cleanup(deviceName: name) }
+
+        // Save a full set of mouse settings
+        let settings = SettingsStore.MouseSettings(
+            dpi: 1600,
+            pointerSpeed: 256,
+            smartShiftActive: true,
+            smartShiftTorque: 50,
+            smartShiftWheelMode: 2,
+            hiResEnabled: true,
+            hiResInverted: false,
+            thumbWheelInverted: true,
+            buttonRemaps: [82: 86],
+            gestureClickTimeLimit: 0.25,
+            gestureDragThreshold: 200
+        )
+        SettingsStore.saveMouseSettings(settings, deviceName: name)
+
+        // Verify saved
+        let before = SettingsStore.loadMouseSettings(deviceName: name)
+        #expect(before.dpi == 1600)
+        #expect(before.pointerSpeed == 256)
+
+        // Clear
+        SettingsStore.clearMouseSettings(deviceName: name)
+
+        // Verify all fields are nil after clear
+        let after = SettingsStore.loadMouseSettings(deviceName: name)
+        #expect(after.dpi == nil)
+        #expect(after.pointerSpeed == nil)
+        #expect(after.smartShiftActive == nil)
+        #expect(after.smartShiftTorque == nil)
+        #expect(after.smartShiftWheelMode == nil)
+        #expect(after.hiResEnabled == nil)
+        #expect(after.hiResInverted == nil)
+        #expect(after.thumbWheelInverted == nil)
+        #expect(after.buttonRemaps == nil)
+        #expect(after.gestureClickTimeLimit == nil)
+        #expect(after.gestureDragThreshold == nil)
+    }
+
+    @Test func clearKeyboardSettingsRemovesAllKeys() {
+        let name = uniqueDeviceName()
+        defer { cleanup(deviceName: name) }
+
+        let settings = SettingsStore.KeyboardSettings(
+            backlightEnabled: true,
+            backlightLevel: 5,
+            fnInverted: true
+        )
+        SettingsStore.saveKeyboardSettings(settings, deviceName: name)
+
+        // Verify saved
+        let before = SettingsStore.loadKeyboardSettings(deviceName: name)
+        #expect(before.backlightEnabled == true)
+        #expect(before.backlightLevel == 5)
+        #expect(before.fnInverted == true)
+
+        // Clear
+        SettingsStore.clearKeyboardSettings(deviceName: name)
+
+        // Verify all fields are nil
+        let after = SettingsStore.loadKeyboardSettings(deviceName: name)
+        #expect(after.backlightEnabled == nil)
+        #expect(after.backlightLevel == nil)
+        #expect(after.fnInverted == nil)
+    }
+
+    @Test func clearSettingsDoesNotAffectOtherDevices() {
+        let name1 = uniqueDeviceName("Device A")
+        let name2 = uniqueDeviceName("Device B")
+        defer {
+            cleanup(deviceName: name1)
+            cleanup(deviceName: name2)
+        }
+
+        // Save settings for both devices
+        SettingsStore.saveMouseSettings(
+            SettingsStore.MouseSettings(dpi: 1600, pointerSpeed: 256),
+            deviceName: name1
+        )
+        SettingsStore.saveMouseSettings(
+            SettingsStore.MouseSettings(dpi: 3200, pointerSpeed: 512),
+            deviceName: name2
+        )
+
+        // Clear only device A
+        SettingsStore.clearMouseSettings(deviceName: name1)
+
+        // Device A should be cleared
+        let afterA = SettingsStore.loadMouseSettings(deviceName: name1)
+        #expect(afterA.dpi == nil)
+        #expect(afterA.pointerSpeed == nil)
+
+        // Device B should be untouched
+        let afterB = SettingsStore.loadMouseSettings(deviceName: name2)
+        #expect(afterB.dpi == 3200)
+        #expect(afterB.pointerSpeed == 512)
+    }
 }


### PR DESCRIPTION
## Summary

- Add `clearMouseSettings` and `clearKeyboardSettings` methods to `SettingsStore` that remove all saved UserDefaults keys for a device
- Add "Reset to Default" button with confirmation alert to both `MouseDetailView` and `KeyboardDetailView`
- On reset, saved settings are cleared and current values are re-read from the hardware

## Details

Settings keys are maintained as static arrays (`mouseSettingKeys`, `keyboardSettingKeys`) to ensure all keys are cleaned up consistently. The reset button is placed at the bottom of each device detail view with a destructive confirmation dialog to prevent accidental resets.

After clearing, `isFeaturesLoaded` is set to false (triggering the loading spinner) and `loadMouseFeatures()` / `loadKeyboardFeatures()` re-reads all current values from the device.

## Changes

| File | Change |
|---|---|
| `Settings/SettingsStore.swift` | Add `clearMouseSettings`, `clearKeyboardSettings`, and key arrays |
| `UI/DeviceDetailView.swift` | Add reset button + confirmation alert to mouse and keyboard views |

## Testing

- Build: 0 errors
- Tests: 239/239 pass