### PR TITLE
feat(gesture): add vertical thumb gestures for Mission Control and App Exposé

### DIFF
--- a/Sources/MXControl/Gesture/GestureEngine.swift
+++ b/Sources/MXControl/Gesture/GestureEngine.swift
@@ -63,6 +63,23 @@ final class GestureEngine: @unchecked Sendable {
     /// The CID of the thumb/gesture button.
     let thumbCID: UInt16
 
+    // MARK: - Action Callbacks (injectable for testing)
+
+    /// Called when a click gesture is detected. Defaults to `MacActions.missionControl`.
+    var onClick: () -> Void = { MacActions.missionControl() }
+
+    /// Called when a drag-left gesture is detected. Defaults to `MacActions.workspaceRight`.
+    var onDragLeft: () -> Void = { MacActions.workspaceRight() }
+
+    /// Called when a drag-right gesture is detected. Defaults to `MacActions.workspaceLeft`.
+    var onDragRight: () -> Void = { MacActions.workspaceLeft() }
+
+    /// Called when a drag-up gesture is detected. Defaults to `MacActions.missionControl`.
+    var onDragUp: () -> Void = { MacActions.missionControl() }
+
+    /// Called when a drag-down gesture is detected. Defaults to `MacActions.appExpose`.
+    var onDragDown: () -> Void = { MacActions.appExpose() }
+
     // MARK: - Init
 
     init(thumbCID: UInt16 = 0x00C3) {
@@ -99,7 +116,7 @@ final class GestureEngine: @unchecked Sendable {
                 debugLog("[GestureEngine] → CLICK → Mission Control")
                 state = .idle
                 lock.unlock()
-                MacActions.missionControl()
+                onClick()
                 lock.lock()
             }
 
@@ -135,13 +152,13 @@ final class GestureEngine: @unchecked Sendable {
                 debugLog("[GestureEngine] DRAG LEFT (dx=\(accumulatedDeltaX)) → Workspace RIGHT")
                 state = .gesture
                 lock.unlock()
-                MacActions.workspaceRight()
+                onDragLeft()
                 lock.lock()
             } else {
                 debugLog("[GestureEngine] DRAG RIGHT (dx=\(accumulatedDeltaX)) → Workspace LEFT")
                 state = .gesture
                 lock.unlock()
-                MacActions.workspaceLeft()
+                onDragRight()
                 lock.lock()
             }
         } else if absDY >= dragThreshold && absDY > absDX {
@@ -150,13 +167,13 @@ final class GestureEngine: @unchecked Sendable {
                 debugLog("[GestureEngine] DRAG UP (dy=\(accumulatedDeltaY)) → Mission Control")
                 state = .gesture
                 lock.unlock()
-                MacActions.missionControl()
+                onDragUp()
                 lock.lock()
             } else {
                 debugLog("[GestureEngine] DRAG DOWN (dy=\(accumulatedDeltaY)) → App Exposé")
                 state = .gesture
                 lock.unlock()
-                MacActions.appExpose()
+                onDragDown()
                 lock.lock()
             }
         }

--- a/Sources/MXControl/Gesture/MacActions.swift
+++ b/Sources/MXControl/Gesture/MacActions.swift
@@ -24,38 +24,14 @@ enum MacActions {
     // MARK: - Actions
 
     /// Trigger Mission Control (Ctrl+Fn+UpArrow, SymbolicHotKey ID 32).
-    /// If called right after a workspace switch, delays until animation finishes (~1s).
     static func missionControl() {
-        let elapsed = Date().timeIntervalSince(lastWorkspaceSwitchTime)
-        if elapsed < 1.5 {
-            let delay = 1.5 - elapsed
-            debugLog("[MacActions] Mission Control delayed \(String(format: "%.0f", delay * 1000))ms (workspace cooldown)")
-            DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + delay) {
-                postKeyboardShortcut(keyCode: 0x7E)
-                debugLog("[MacActions] Mission Control triggered (after cooldown)")
-            }
-        } else {
-            postKeyboardShortcut(keyCode: 0x7E)  // kVK_UpArrow
-            debugLog("[MacActions] Mission Control triggered")
-        }
+        postWithCooldown(keyCode: 0x7E, label: "Mission Control")  // kVK_UpArrow
     }
 
     /// Trigger App Exposé (Ctrl+Fn+DownArrow, SymbolicHotKey ID 33).
     /// Shows all windows of the frontmost application.
-    /// Respects the same cooldown as Mission Control after workspace switches.
     static func appExpose() {
-        let elapsed = Date().timeIntervalSince(lastWorkspaceSwitchTime)
-        if elapsed < 1.5 {
-            let delay = 1.5 - elapsed
-            debugLog("[MacActions] App Exposé delayed \(String(format: "%.0f", delay * 1000))ms (workspace cooldown)")
-            DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + delay) {
-                postKeyboardShortcut(keyCode: 0x7D)
-                debugLog("[MacActions] App Exposé triggered (after cooldown)")
-            }
-        } else {
-            postKeyboardShortcut(keyCode: 0x7D)  // kVK_DownArrow
-            debugLog("[MacActions] App Exposé triggered")
-        }
+        postWithCooldown(keyCode: 0x7D, label: "App Exposé")  // kVK_DownArrow
     }
 
     /// Switch to the workspace on the LEFT (Ctrl+Fn+LeftArrow, SymbolicHotKey ID 79).
@@ -70,6 +46,25 @@ enum MacActions {
         lastWorkspaceSwitchTime = Date()
         postKeyboardShortcut(keyCode: 0x7C)  // kVK_RightArrow
         debugLog("[MacActions] Workspace Right triggered")
+    }
+
+    // MARK: - Cooldown Helper
+
+    /// Post a keyboard shortcut, respecting the workspace switch cooldown.
+    /// If called within 1.5s of a workspace switch, delays until animation finishes.
+    private static func postWithCooldown(keyCode: CGKeyCode, label: String) {
+        let elapsed = Date().timeIntervalSince(lastWorkspaceSwitchTime)
+        if elapsed < 1.5 {
+            let delay = 1.5 - elapsed
+            debugLog("[MacActions] \(label) delayed \(String(format: "%.0f", delay * 1000))ms (workspace cooldown)")
+            DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + delay) {
+                postKeyboardShortcut(keyCode: keyCode)
+                debugLog("[MacActions] \(label) triggered (after cooldown)")
+            }
+        } else {
+            postKeyboardShortcut(keyCode: keyCode)
+            debugLog("[MacActions] \(label) triggered")
+        }
     }
 
     // MARK: - CGEvent Keyboard Shortcut

--- a/Tests/MXControlTests/GestureEngineTests.swift
+++ b/Tests/MXControlTests/GestureEngineTests.swift
@@ -1,0 +1,237 @@
+import Testing
+import Foundation
+@testable import MXControl
+
+@Suite("GestureEngine")
+struct GestureEngineTests {
+
+    /// Helper: create a GestureEngine with spy callbacks and a short click time for fast tests.
+    private func makeEngine(
+        clickTimeLimit: TimeInterval = 0.01,
+        dragThreshold: Int = 100
+    ) -> (engine: GestureEngine, actions: ActionSpy) {
+        let spy = ActionSpy()
+        let engine = GestureEngine(thumbCID: 0x00C3)
+        engine.updateConfig(clickTimeLimit: clickTimeLimit, dragThreshold: dragThreshold)
+        engine.onClick = { spy.record(.click) }
+        engine.onDragLeft = { spy.record(.dragLeft) }
+        engine.onDragRight = { spy.record(.dragRight) }
+        engine.onDragUp = { spy.record(.dragUp) }
+        engine.onDragDown = { spy.record(.dragDown) }
+        return (engine, spy)
+    }
+
+    /// Wait for the click time window to elapse.
+    private func waitPastClickTime(_ limit: TimeInterval = 0.01) {
+        Thread.sleep(forTimeInterval: limit + 0.005)
+    }
+
+    // MARK: - Click Gesture
+
+    @Test func clickOnQuickRelease() {
+        let (engine, spy) = makeEngine()
+
+        // Press thumb button
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        // Release immediately (within clickTimeLimit)
+        engine.handleButtonEvent(pressedCIDs: [])
+
+        #expect(spy.actions == [.click])
+    }
+
+    @Test func clickOnReleaseWithoutThreshold() {
+        let (engine, spy) = makeEngine()
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Move a little but not enough to cross threshold
+        engine.handleRawXY(deltaX: 10, deltaY: 5)
+
+        // Release — should still be click since threshold not met
+        engine.handleButtonEvent(pressedCIDs: [])
+
+        #expect(spy.actions == [.click])
+    }
+
+    // MARK: - Horizontal Gestures
+
+    @Test func dragLeftTriggersWorkspaceRight() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Drag left (negative deltaX)
+        engine.handleRawXY(deltaX: -50, deltaY: 0)
+        engine.handleRawXY(deltaX: -60, deltaY: 0)  // total: -110, exceeds 100
+
+        #expect(spy.actions == [.dragLeft])
+
+        // Release should not trigger click
+        engine.handleButtonEvent(pressedCIDs: [])
+        #expect(spy.actions == [.dragLeft])
+    }
+
+    @Test func dragRightTriggersWorkspaceLeft() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        engine.handleRawXY(deltaX: 60, deltaY: 0)
+        engine.handleRawXY(deltaX: 50, deltaY: 0)  // total: 110
+
+        #expect(spy.actions == [.dragRight])
+    }
+
+    // MARK: - Vertical Gestures
+
+    @Test func dragUpTriggersMissionControl() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Drag up (negative deltaY)
+        engine.handleRawXY(deltaX: 0, deltaY: -60)
+        engine.handleRawXY(deltaX: 0, deltaY: -50)  // total: -110
+
+        #expect(spy.actions == [.dragUp])
+    }
+
+    @Test func dragDownTriggersAppExpose() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Drag down (positive deltaY)
+        engine.handleRawXY(deltaX: 0, deltaY: 60)
+        engine.handleRawXY(deltaX: 0, deltaY: 50)  // total: 110
+
+        #expect(spy.actions == [.dragDown])
+    }
+
+    // MARK: - Axis Dominance
+
+    @Test func diagonalResolvesToDominantHorizontal() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Diagonal with stronger horizontal component
+        engine.handleRawXY(deltaX: -80, deltaY: 40)
+        engine.handleRawXY(deltaX: -40, deltaY: 20)  // dx=-120, dy=60 → horizontal wins
+
+        #expect(spy.actions == [.dragLeft])
+    }
+
+    @Test func diagonalResolvesToDominantVertical() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Diagonal with stronger vertical component
+        engine.handleRawXY(deltaX: 30, deltaY: -70)
+        engine.handleRawXY(deltaX: 20, deltaY: -50)  // dx=50, dy=-120 → vertical wins
+
+        #expect(spy.actions == [.dragUp])
+    }
+
+    @Test func tieBreakFavorsHorizontal() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Equal magnitudes: |dx| == |dy| == 110 → horizontal wins (absDX >= absDY)
+        engine.handleRawXY(deltaX: -110, deltaY: -110)
+
+        #expect(spy.actions == [.dragLeft])
+    }
+
+    // MARK: - Click-First Guarantee
+
+    @Test func movementDuringClickWindowIgnored() {
+        let (engine, spy) = makeEngine(clickTimeLimit: 0.05, dragThreshold: 50)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+
+        // Massive movement DURING click time window
+        engine.handleRawXY(deltaX: -500, deltaY: 0)
+
+        // Release within click time → should be click, not drag
+        engine.handleButtonEvent(pressedCIDs: [])
+
+        #expect(spy.actions == [.click])
+    }
+
+    // MARK: - No Double-Fire
+
+    @Test func gestureDoesNotFireTwice() {
+        let (engine, spy) = makeEngine(dragThreshold: 100)
+
+        engine.handleButtonEvent(pressedCIDs: [0x00C3])
+        waitPastClickTime()
+
+        // Cross threshold
+        engine.handleRawXY(deltaX: -120, deltaY: 0)
+        #expect(spy.actions == [.dragLeft])
+
+        // Keep moving — should NOT fire again
+        engine.handleRawXY(deltaX: -200, deltaY: 0)
+        #expect(spy.actions == [.dragLeft])
+
+        // Release — should NOT fire click
+        engine.handleButtonEvent(pressedCIDs: [])
+        #expect(spy.actions == [.dragLeft])
+    }
+
+    // MARK: - Ignores Other CIDs
+
+    @Test func ignoresNonThumbButton() {
+        let (engine, spy) = makeEngine()
+
+        // Press a different button (middle click CID=82)
+        engine.handleButtonEvent(pressedCIDs: [82])
+        engine.handleButtonEvent(pressedCIDs: [])
+
+        #expect(spy.actions.isEmpty)
+    }
+}
+
+// MARK: - Test Helpers
+
+private final class ActionSpy: @unchecked Sendable {
+    enum Action: Equatable, CustomStringConvertible {
+        case click, dragLeft, dragRight, dragUp, dragDown
+
+        var description: String {
+            switch self {
+            case .click: "click"
+            case .dragLeft: "dragLeft"
+            case .dragRight: "dragRight"
+            case .dragUp: "dragUp"
+            case .dragDown: "dragDown"
+            }
+        }
+    }
+
+    private let lock = NSLock()
+    private var _actions: [Action] = []
+
+    var actions: [Action] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _actions
+    }
+
+    func record(_ action: Action) {
+        lock.lock()
+        defer { lock.unlock() }
+        _actions.append(action)
+    }
+}


### PR DESCRIPTION
## Summary

- Extend `GestureEngine` to detect vertical drag gestures on the thumb button
- Hold + drag up triggers Mission Control
- Hold + drag down triggers App Exposé (all windows of frontmost app)
- Add `MacActions.appExpose()` using `Ctrl+Fn+DownArrow` (SymbolicHotKey 33)

## Details

The gesture engine now uses **axis-dominant detection**: after the click time window elapses, whichever axis (`|deltaX|` vs `|deltaY|`) exceeds the drag threshold first wins. This prevents diagonal confusion — you can't accidentally trigger both a workspace switch and a vertical gesture.

The click-first guarantee is preserved: any release within `clickTimeLimit` (200ms default) is always treated as a click regardless of movement.

Direction mapping:
- Drag up (negative deltaY) → Mission Control
- Drag down (positive deltaY) → App Exposé
- Drag left (negative deltaX) → Workspace Right (existing)
- Drag right (positive deltaX) → Workspace Left (existing)

`appExpose()` uses the same cooldown logic as `missionControl()` — if called within 1.5s of a workspace switch, it delays until the animation finishes.

## Changes

| File | Change |
|---|---|
| `Gesture/GestureEngine.swift` | Add vertical axis detection in `handleRawXY` |
| `Gesture/MacActions.swift` | Add `appExpose()` method |

## Testing

- Build: 0 errors
- Tests: 239/239 pass