### PR TITLE
feat(battery): add low battery notifications at 20% and 10%

### DIFF
--- a/Sources/MXControl/App.swift
+++ b/Sources/MXControl/App.swift
@@ -28,6 +28,7 @@ struct MXControlApp: App {
 
     init() {
         AppVisibilityPreferences.registerDefaults()
+        BatteryNotifier.setup()
     }
 
     var body: some Scene {

--- a/Sources/MXControl/Device/DeviceManager.swift
+++ b/Sources/MXControl/Device/DeviceManager.swift
@@ -177,6 +177,7 @@ final class DeviceManager {
         initializingBLEUIDs.removeAll()
         initializedBLEUIDs.removeAll()
         failedBLEUIDs.removeAll()
+        BatteryNotifier.reset()
         isScanning = false
         statusMessage = "Stopped"
     }
@@ -684,8 +685,18 @@ final class DeviceManager {
                 for device in self.devices {
                     if let mouse = device as? MouseDevice {
                         await mouse.refreshBattery()
+                        BatteryNotifier.checkAndNotify(
+                            deviceName: mouse.name,
+                            level: mouse.batteryLevel,
+                            isCharging: mouse.batteryCharging
+                        )
                     } else if let keyboard = device as? KeyboardDevice {
                         await keyboard.refreshBattery()
+                        BatteryNotifier.checkAndNotify(
+                            deviceName: keyboard.name,
+                            level: keyboard.batteryLevel,
+                            isCharging: keyboard.batteryCharging
+                        )
                     }
                 }
                 logger.debug("[DeviceManager] Battery refresh complete")

--- a/Sources/MXControl/Settings/BatteryNotifier.swift
+++ b/Sources/MXControl/Settings/BatteryNotifier.swift
@@ -1,0 +1,121 @@
+import Foundation
+import UserNotifications
+import os
+
+/// Sends native macOS notifications when device battery drops below thresholds.
+///
+/// Two levels:
+///   - **Warning** at 20%: "Battery Low"
+///   - **Critical** at 10%: "Battery Critical"
+///
+/// Notifications are deduplicated per device per charge cycle.
+/// Once a level triggers, it won't fire again until the device starts charging
+/// (which resets the notification state).
+enum BatteryNotifier {
+
+    // MARK: - Thresholds
+
+    static let warningThreshold = 20
+    static let criticalThreshold = 10
+
+    // MARK: - Notification State
+
+    /// Tracks which notifications have been sent per device to avoid spam.
+    struct NotificationState {
+        var warningSent: Bool = false
+        var criticalSent: Bool = false
+    }
+
+    /// Per-device notification state, keyed by device name.
+    /// Reset when charging is detected.
+    nonisolated(unsafe) private static var state: [String: NotificationState] = [:]
+
+    // MARK: - Setup
+
+    /// Request notification permission. Call once at app launch.
+    static func setup() {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                logger.warning("[BatteryNotifier] Permission error: \(error.localizedDescription)")
+            } else {
+                logger.info("[BatteryNotifier] Notification permission granted: \(granted)")
+            }
+        }
+    }
+
+    // MARK: - Check and Notify
+
+    /// Check battery level and send notifications if thresholds are crossed.
+    ///
+    /// Call this after every battery refresh poll.
+    /// - Parameters:
+    ///   - deviceName: Human-readable device name (e.g., "MX Master 3S")
+    ///   - level: Battery percentage (0-100)
+    ///   - isCharging: Whether the device is currently charging
+    @MainActor
+    static func checkAndNotify(deviceName: String, level: Int, isCharging: Bool) {
+        var deviceState = state[deviceName] ?? NotificationState()
+
+        // Reset notification state when charging starts (allows re-notify on next discharge)
+        if isCharging {
+            if deviceState.warningSent || deviceState.criticalSent {
+                logger.debug("[BatteryNotifier] \(deviceName) charging — reset notification state")
+            }
+            deviceState.warningSent = false
+            deviceState.criticalSent = false
+            state[deviceName] = deviceState
+            return
+        }
+
+        // Critical: 10% or below
+        if level <= criticalThreshold && !deviceState.criticalSent {
+            sendNotification(
+                title: "Battery Critical",
+                body: "\(deviceName) battery is at \(level)%. Charge soon.",
+                identifier: "\(deviceName)-critical"
+            )
+            deviceState.criticalSent = true
+            deviceState.warningSent = true  // Don't also fire warning
+            logger.info("[BatteryNotifier] \(deviceName) critical notification sent (\(level)%)")
+        }
+        // Warning: 20% or below
+        else if level <= warningThreshold && !deviceState.warningSent {
+            sendNotification(
+                title: "Battery Low",
+                body: "\(deviceName) battery is at \(level)%.",
+                identifier: "\(deviceName)-warning"
+            )
+            deviceState.warningSent = true
+            logger.info("[BatteryNotifier] \(deviceName) warning notification sent (\(level)%)")
+        }
+
+        state[deviceName] = deviceState
+    }
+
+    // MARK: - Send
+
+    private static func sendNotification(title: String, body: String, identifier: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: nil  // Deliver immediately
+        )
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                logger.warning("[BatteryNotifier] Failed to send notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Clear all tracked state (e.g., when all devices disconnect).
+    static func reset() {
+        state.removeAll()
+    }
+}


### PR DESCRIPTION
## Summary

- Add `BatteryNotifier` that sends native macOS notifications when battery drops below thresholds
- Warning at 20%: "Battery Low"
- Critical at 10%: "Battery Critical"
- Notifications are deduplicated per device per charge cycle

## Details

`BatteryNotifier` is a stateless enum namespace with static methods. It tracks per-device notification state and ensures each threshold only fires once per discharge cycle. When charging is detected, the state resets so notifications can fire again on the next discharge.

The notifier integrates into the existing 5-minute battery refresh loop in `DeviceManager`. After each `refreshBattery()` call, `BatteryNotifier.checkAndNotify()` is called with the updated level and charging status.

Notification permission is requested on app launch via `UNUserNotificationCenter`. State is cleared when discovery stops (all devices disconnect).

## Changes

| File | Change |
|---|---|
| **New:** `Settings/BatteryNotifier.swift` | Battery notification logic with dedup state |
| `Device/DeviceManager.swift` | Integrate `checkAndNotify` into battery refresh loop + `reset()` on stop |
| `App.swift` | Call `BatteryNotifier.setup()` on init |

## Testing

- Build: 0 errors
- Tests: 239/239 pass